### PR TITLE
Validate all word/ documents not just document.xml

### DIFF
--- a/validate
+++ b/validate
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
 
 if [ "$1" != "" ]; then
-  unzip -o -j "$1" -d "./tmp"
-  xmllint --format "./tmp/document.xml" > "./tmp/document-pretty.xml"
-  # xmllint --format "./tmp/document2.xml" > "./tmp/document2-pretty.xml"
+  rm -rf tmp
+  unzip -j -o "$1" "word/*.xml" -d "./tmp"
+  for i in ./tmp/*.xml; do
+    xmllint --format "${i}" > "${i}.pretty.xml"
+  done
 fi
 
-xmllint -noout -nonet \
-  -schema "./schemas/microsoft/wml-2010.xsd" \
-  "./tmp/document-pretty.xml" 2>&1
+XSD="schemas/microsoft/wml-2010.xsd"
 
+failed=0
+for i in ./tmp/*.pretty.xml; do
+  xmllint -noout -nonet \
+    -schema "${XSD}" \
+    "${i}" 2>&1 || failed=1
+done
+exit "${failed}"


### PR DESCRIPTION
There are also styles.xml and numbering.xml, etc.
The schema for all of these are in wml.xsd.

Try to validate all XML files, show all validation errors and then exit with a failure if any XML failed to validate.
This way you get to see all validation errors from all XML files in one go (instead of failing early on one and not seeing the rest).

Also cleanup before unpacking to avoid confusing validation errors from one document with another (in case they have different files inside).

This validator has been very useful for making `pandoc`'s docx output validate